### PR TITLE
Run paper evidence on broker host

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   paper:
     name: IB and Alpaca paper evidence
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ib-paper]
     timeout-minutes: 45
     environment: paper
     permissions:


### PR DESCRIPTION
## What changed

- Route the manual paper qualification job to a narrowly labeled self-hosted Linux runner.

## Why

- IB Gateway is authenticated on the broker host and listens only on its local API port.
- A GitHub-hosted runner cannot reach that local endpoint.
- No pull-request workflow requests the `ib-paper` label.

## Validation

- Candidate workflow policy check passes against this workflow.
