### PR TITLE
Fix PyPI publisher pin and add exact-artifact recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,27 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      candidate-sha:
+        description: Exact qualified commit to recover
+        required: true
+        type: string
+      qualification-run-id:
+        description: Failed release run containing qualified artifacts
+        required: true
+        type: string
+      tag:
+        description: Existing version tag for the candidate
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
   qualification:
     name: Complete stable qualification
+    if: github.event_name == 'push'
     permissions:
       actions: read
       contents: read
@@ -25,6 +40,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}
       - name: Match successful retained evidence to this commit
         id: paper
         env:
@@ -32,7 +49,7 @@ jobs:
         run: >-
           python scripts/qualification/check_paper_evidence.py
           --repository "${{ github.repository }}"
-          --commit "${{ github.sha }}"
+          --commit "${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}"
           --max-age-days 7
           --github-output "$GITHUB_OUTPUT"
 
@@ -77,7 +94,7 @@ jobs:
           --tag "${{ github.ref_name }}"
           --paper-wheel-sha256 "$PAPER_WHEEL_SHA256"
           --paper-sdist-sha256 "$PAPER_SDIST_SHA256"
-      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
           verify-metadata: true
@@ -105,6 +122,93 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >-
           gh release create "${{ github.ref_name }}"
+          dist/*
+          security-evidence/sbom.cdx.json
+          security-evidence/dependency-snapshot.json
+          --generate-notes
+          --verify-tag
+
+  recovery-publish:
+    name: Recover exact candidate publication to PyPI
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: paper-evidence
+    environment: pypi
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.candidate-sha }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification-run-id }}
+          name: dist-${{ inputs.candidate-sha }}
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification-run-id }}
+          name: qualification-${{ inputs.candidate-sha }}
+          path: qualification-evidence/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification-run-id }}
+          name: security-${{ inputs.candidate-sha }}
+          path: security-evidence/
+      - name: Match tag, commit, artifacts, provider evidence, SBOM, and snapshot
+        env:
+          PAPER_WHEEL_SHA256: ${{ needs.paper-evidence.outputs.wheel_sha256 }}
+          PAPER_SDIST_SHA256: ${{ needs.paper-evidence.outputs.sdist_sha256 }}
+        run: >-
+          python scripts/qualification/verify_release_identity.py
+          --artifacts-dir dist
+          --artifact-report qualification-evidence/artifact-qualification.json
+          --security-report security-evidence/security-report.json
+          --sbom security-evidence/sbom.cdx.json
+          --dependency-snapshot security-evidence/dependency-snapshot.json
+          --commit "${{ inputs.candidate-sha }}"
+          --tag "${{ inputs.tag }}"
+          --paper-wheel-sha256 "$PAPER_WHEEL_SHA256"
+          --paper-sdist-sha256 "$PAPER_SDIST_SHA256"
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/
+          verify-metadata: true
+          print-hash: true
+          attestations: true
+
+  recovery-github-release:
+    name: Create recovered GitHub release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: recovery-publish
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification-run-id }}
+          name: dist-${{ inputs.candidate-sha }}
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification-run-id }}
+          name: security-${{ inputs.candidate-sha }}
+          path: security-evidence/
+      - name: Create release for the published tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${{ inputs.tag }}"
           dist/*
           security-evidence/sbom.cdx.json
           security-evidence/dependency-snapshot.json

--- a/scripts/qualification/check_workflows.py
+++ b/scripts/qualification/check_workflows.py
@@ -180,6 +180,56 @@ def promotion_failures(qualification: dict[str, Any], release: dict[str, Any]) -
     return failures
 
 
+def release_recovery_failures(release: dict[str, Any]) -> list[str]:
+    """Reject recovery paths that can publish without the original evidence."""
+    failures = []
+    recovery_publish = release.get("jobs", {}).get("recovery-publish", {})
+    if _needs(recovery_publish) != {"paper-evidence"}:
+        failures.append("recovery publish does not require fresh paper evidence")
+    if recovery_publish.get("if") != "github.event_name == 'workflow_dispatch'":
+        failures.append("recovery publish is not restricted to manual dispatch")
+    recovery_downloads = _action_steps(recovery_publish, "actions/download-artifact")
+    expected_recovery_downloads = {
+        "dist-${{ inputs.candidate-sha }}",
+        "qualification-${{ inputs.candidate-sha }}",
+        "security-${{ inputs.candidate-sha }}",
+    }
+    if {step.get("with", {}).get("name") for step in recovery_downloads} != (
+        expected_recovery_downloads
+    ) or any(
+        step.get("with", {}).get("run-id") != "${{ inputs.qualification-run-id }}"
+        for step in recovery_downloads
+    ):
+        failures.append("recovery publish does not use every exact source-run artifact")
+    recovery_text = json.dumps(recovery_publish, sort_keys=True)
+    for required in (
+        "needs.paper-evidence.outputs.wheel_sha256",
+        "needs.paper-evidence.outputs.sdist_sha256",
+        "verify_release_identity.py",
+        "inputs.candidate-sha",
+        "inputs.tag",
+    ):
+        if required not in recovery_text:
+            failures.append(f"recovery identity check omits: {required}")
+    recovery_publishers = _action_steps(recovery_publish, "pypa/gh-action-pypi-publish")
+    if (
+        len(recovery_publishers) != 1
+        or recovery_publishers[0].get("with", {}).get("attestations") != "true"
+    ):
+        failures.append("recovery publish does not preserve trusted provenance attestations")
+    recovery_release = release.get("jobs", {}).get("recovery-github-release", {})
+    if _needs(recovery_release) != {"recovery-publish"}:
+        failures.append("recovered GitHub release does not require successful publication")
+    if recovery_release.get("if") != "github.event_name == 'workflow_dispatch'":
+        failures.append("recovered GitHub release is not restricted to manual dispatch")
+    recovery_release_text = _run_text(recovery_release)
+    if "sbom.cdx.json" not in recovery_release_text or "dependency-snapshot.json" not in (
+        recovery_release_text
+    ):
+        failures.append("recovered GitHub release does not retain security evidence")
+    return failures
+
+
 def paper_soak_failures(paper_job: dict[str, Any]) -> list[str]:
     """Reject a long soak that can start after a short provider check fails."""
     soak_steps = [step for step in _steps(paper_job) if step.get("id") == "provider-soaks"]
@@ -305,11 +355,16 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     ):
         failures.append("CI does not call the reusable qualification workflow")
 
-    if _triggers(release) != {"push"}:
-        failures.append("release has a non-tag trigger")
+    if _triggers(release) != {"push", "workflow_dispatch"}:
+        failures.append("release triggers differ from tag publication and manual recovery")
     release_push = release.get("on", {}).get("push", {})
     if not isinstance(release_push, dict) or _list(release_push.get("tags")) != ["v*"]:
         failures.append("release is not restricted to version tags")
+    recovery_inputs = release.get("on", {}).get("workflow_dispatch", {}).get("inputs", {})
+    if set(recovery_inputs) != {"candidate-sha", "qualification-run-id", "tag"} or any(
+        value.get("required") != "true" for value in recovery_inputs.values()
+    ):
+        failures.append("release recovery does not require the candidate, source run, and tag")
     failures.extend(promotion_failures(qualification, release))
     publish_job = release.get("jobs", {}).get("publish", {})
     publish_download_names = {
@@ -329,6 +384,8 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     release_text = _run_text(release.get("jobs", {}).get("github-release", {}))
     if "sbom.cdx.json" not in release_text or "dependency-snapshot.json" not in release_text:
         failures.append("GitHub release does not retain the SBOM and dependency snapshot")
+
+    failures.extend(release_recovery_failures(release))
 
     stable_workflow_text = json.dumps(qualification, sort_keys=True).casefold()
     if "0.1.0b" in stable_workflow_text or "beta" in stable_workflow_text:
@@ -397,6 +454,8 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     allowed_job_writes = {
         ("release.yml", "publish"): {"id-token"},
         ("release.yml", "github-release"): {"contents"},
+        ("release.yml", "recovery-publish"): {"id-token"},
+        ("release.yml", "recovery-github-release"): {"contents"},
     }
     for workflow_name, workflow in workflows.items():
         for job_name, job in workflow.get("jobs", {}).items():

--- a/tests/unit/test_workflow_policy.py
+++ b/tests/unit/test_workflow_policy.py
@@ -10,6 +10,7 @@ from scripts.qualification.check_workflows import (
     load_workflow,
     paper_soak_failures,
     promotion_failures,
+    release_recovery_failures,
     validate_workflows,
 )
 
@@ -82,3 +83,39 @@ def test_seeded_mandatory_failure_cannot_reach_publish(mutation: str, expected: 
     assert any(
         expected in failure for failure in promotion_failures(seeded_qualification, seeded_release)
     )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ("missing-paper", "fresh paper evidence"),
+        ("wrong-source-run", "exact source-run artifact"),
+        ("missing-attestation", "trusted provenance attestations"),
+        ("early-release", "successful publication"),
+    ],
+)
+def test_seeded_recovery_failure_is_rejected(mutation: str, expected: str) -> None:
+    release = load_workflow(WORKFLOW_ROOT / "release.yml")
+    seeded_release = deepcopy(release)
+    recovery_publish = seeded_release["jobs"]["recovery-publish"]
+
+    if mutation == "missing-paper":
+        recovery_publish["needs"] = []
+    elif mutation == "wrong-source-run":
+        download = next(
+            step
+            for step in recovery_publish["steps"]
+            if str(step.get("uses", "")).startswith("actions/download-artifact@")
+        )
+        download["with"]["run-id"] = "123"
+    elif mutation == "missing-attestation":
+        publisher = next(
+            step
+            for step in recovery_publish["steps"]
+            if str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@")
+        )
+        publisher["with"]["attestations"] = "false"
+    else:
+        seeded_release["jobs"]["recovery-github-release"]["needs"] = "paper-evidence"
+
+    assert any(expected in failure for failure in release_recovery_failures(seeded_release))


### PR DESCRIPTION
The v0.1.0 release reached publication after every qualification gate passed, then failed before upload because the workflow pinned the annotated v1.14.0 tag object instead of its commit. The generated publisher container therefore referenced a nonexistent image. This change pins the dereferenced v1.14.0 commit and adds a protected manual recovery path. Recovery reuses only commit-addressed artifacts from the failed release run, rechecks fresh paper hashes and release identity, publishes with trusted provenance attestations, and creates the GitHub release only after publication succeeds.