### PR TITLE
Fix GitHub release repository targeting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
           security-evidence/sbom.cdx.json
           security-evidence/dependency-snapshot.json
           --generate-notes
+          --repo "${{ github.repository }}"
           --verify-tag
 
   recovery-publish:
@@ -213,4 +214,5 @@ jobs:
           security-evidence/sbom.cdx.json
           security-evidence/dependency-snapshot.json
           --generate-notes
+          --repo "${{ github.repository }}"
           --verify-tag

--- a/scripts/qualification/check_workflows.py
+++ b/scripts/qualification/check_workflows.py
@@ -227,6 +227,8 @@ def release_recovery_failures(release: dict[str, Any]) -> list[str]:
         recovery_release_text
     ):
         failures.append("recovered GitHub release does not retain security evidence")
+    if '--repo "${{ github.repository }}"' not in recovery_release_text:
+        failures.append("recovered GitHub release does not address its repository explicitly")
     return failures
 
 
@@ -384,6 +386,8 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     release_text = _run_text(release.get("jobs", {}).get("github-release", {}))
     if "sbom.cdx.json" not in release_text or "dependency-snapshot.json" not in release_text:
         failures.append("GitHub release does not retain the SBOM and dependency snapshot")
+    if '--repo "${{ github.repository }}"' not in release_text:
+        failures.append("GitHub release does not address its repository explicitly")
 
     failures.extend(release_recovery_failures(release))
 

--- a/tests/unit/test_workflow_policy.py
+++ b/tests/unit/test_workflow_policy.py
@@ -92,6 +92,7 @@ def test_seeded_mandatory_failure_cannot_reach_publish(mutation: str, expected: 
         ("wrong-source-run", "exact source-run artifact"),
         ("missing-attestation", "trusted provenance attestations"),
         ("early-release", "successful publication"),
+        ("missing-repository", "repository explicitly"),
     ],
 )
 def test_seeded_recovery_failure_is_rejected(mutation: str, expected: str) -> None:
@@ -115,7 +116,12 @@ def test_seeded_recovery_failure_is_rejected(mutation: str, expected: str) -> No
             if str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@")
         )
         publisher["with"]["attestations"] = "false"
-    else:
+    elif mutation == "early-release":
         seeded_release["jobs"]["recovery-github-release"]["needs"] = "paper-evidence"
+    else:
+        release_step = seeded_release["jobs"]["recovery-github-release"]["steps"][-1]
+        release_step["run"] = str(release_step["run"]).replace(
+            '--repo "${{ github.repository }}"', ""
+        )
 
     assert any(expected in failure for failure in release_recovery_failures(seeded_release))


### PR DESCRIPTION
The recovered v0.1.0 publication reached PyPI, but the GitHub release job ran without a checkout and did not pass an explicit repository to gh. Add explicit repository targeting to both release paths and enforce it in the adversarial workflow policy tests.