### PR TITLE
docs: point AGENTS.md at the book-guide chapter-to-API cross-reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,5 @@ Codex uses `AGENTS.md` as the repo entry point.
 
 - `src/ml4t/live/AGENTS.md` provides the package-level module index
 - Public entry point: `from ml4t.live import LiveEngine`
+- `docs/book-guide/index.md` provides the chapter-to-API cross-reference (book notebook -> concept
+  -> `ml4t.live` API -> docs page)


### PR DESCRIPTION
## Summary
- AGENTS.md had no pointer to the existing docs/book-guide/index.md chapter-notebook-to-API mapping, unlike ml4t-engineer and ml4t-diagnostic. Adds one line under Navigation.

## Test plan
- Docs-only change; pre-commit hooks pass.