### PR TITLE
fix: reconcile Alpaca positions after material fills

### DIFF
--- a/src/ml4t/live/brokers/alpaca.py
+++ b/src/ml4t/live/brokers/alpaca.py
@@ -100,6 +100,7 @@ class AlpacaBroker:
         self._alpaca_order_map: dict[str, tuple[str, float]] = {}
         self._account_id: str | None = None
         self._snapshot_error: RuntimeError | None = None
+        self._position_snapshot_poisoned = False
 
     @property
     def execution_capabilities(self) -> frozenset[ExecutionCapability]:
@@ -135,6 +136,7 @@ class AlpacaBroker:
         mode = "paper" if self._paper else "LIVE"
         logger.info(f"AlpacaBroker: Connecting ({mode} trading)")
         self._snapshot_error = None
+        self._position_snapshot_poisoned = False
 
         try:
             # Create REST client
@@ -279,6 +281,8 @@ class AlpacaBroker:
         Returns:
             Dictionary mapping asset symbols to Position objects
         """
+        if self._position_snapshot_poisoned:
+            self._raise_snapshot_error()
         return dict(self._positions)  # Shallow copy is atomic for small dicts
 
     @property
@@ -299,6 +303,8 @@ class AlpacaBroker:
         Returns:
             Position object if exists, None otherwise
         """
+        if self._position_snapshot_poisoned:
+            self._raise_snapshot_error()
         return self._positions.get(asset.upper())
 
     async def get_positions_async(self) -> dict[str, Position]:
@@ -469,17 +475,45 @@ class AlpacaBroker:
                 created_at=alpaca_order.created_at or datetime.now(UTC),
             )
 
-            if order.status is OrderStatus.FILLED:
+            if alpaca_order.status in {
+                AlpacaOrderStatus.FILLED,
+                AlpacaOrderStatus.PARTIALLY_FILLED,
+            }:
                 if alpaca_order.filled_qty is None or alpaca_order.filled_avg_price is None:
-                    raise RuntimeError("Alpaca filled order is missing fill evidence")
-                order.filled_quantity = float(alpaca_order.filled_qty)
-                order.filled_price = float(alpaca_order.filled_avg_price)
+                    raise RuntimeError("Alpaca material fill is missing fill evidence")
+                try:
+                    filled_quantity = float(alpaca_order.filled_qty)
+                    filled_price = float(alpaca_order.filled_avg_price)
+                except (TypeError, ValueError) as error:
+                    raise RuntimeError(
+                        "Alpaca material fill contains non-numeric evidence"
+                    ) from error
+                if (
+                    not math.isfinite(filled_quantity)
+                    or filled_quantity <= 0
+                    or filled_quantity > order.quantity
+                    or (
+                        alpaca_order.status is AlpacaOrderStatus.FILLED
+                        and filled_quantity != order.quantity
+                    )
+                    or not math.isfinite(filled_price)
+                    or filled_price <= 0
+                ):
+                    raise RuntimeError("Alpaca material fill contains invalid evidence")
+                order.filled_quantity = filled_quantity
+                order.filled_price = filled_price
                 order.filled_at = getattr(alpaca_order, "filled_at", None) or datetime.now(UTC)
 
             # Track order
             if order.status is OrderStatus.PENDING:
                 self._pending_orders[order_id] = order
                 self._alpaca_order_map[str(alpaca_order.id)] = (order_id, time.time())
+
+        if order.filled_quantity > 0:
+            try:
+                await self._sync_positions()
+            except Exception as error:
+                self._poison_snapshot("position", error)
 
         logger.info(f"AlpacaBroker: Order {order_id} submitted: {side.value} {qty} {asset}")
         return order
@@ -773,6 +807,7 @@ class AlpacaBroker:
                 if filled_price > 0 and math.isfinite(filled_price):
                     order.filled_price = filled_price
                 logger.info(f"AlpacaBroker: Order {order_id} partial fill: {order.filled_quantity}")
+                await self._sync_positions()
 
             elif event in ("canceled", "expired", "rejected"):
                 # Terminal state - update status and cleanup immediately
@@ -819,10 +854,14 @@ class AlpacaBroker:
                 raise RuntimeError(f"unsupported Alpaca order event {event!r}")
 
         except Exception as e:
-            detail = str(redact_sensitive(str(e)))
-            self._snapshot_error = RuntimeError(f"Alpaca order state is unavailable: {detail}")
-            self._connected = False
-            logger.error("AlpacaBroker: Error processing trade update: %s", detail)
+            self._poison_snapshot("order", e)
+
+    def _poison_snapshot(self, state: str, error: Exception) -> None:
+        detail = str(redact_sensitive(str(error)))
+        self._snapshot_error = RuntimeError(f"Alpaca {state} state is unavailable: {detail}")
+        self._position_snapshot_poisoned = True
+        self._connected = False
+        logger.error("AlpacaBroker: %s state is unavailable: %s", state, detail)
 
     async def _run_trading_stream(self) -> None:
         """Run TradingStream in background thread.

--- a/src/ml4t/live/engine.py
+++ b/src/ml4t/live/engine.py
@@ -489,6 +489,12 @@ class LiveEngine:
                     if self._shutdown_event.is_set():
                         logger.info("LiveEngine: Shutdown requested")
                         break
+                    if self._current_broker_connected() is False:
+                        self._terminal_failure_reason = "broker_disconnected"
+                        self._shutdown_event.set()
+                        raise RuntimeError(
+                            "Broker disconnected before the next strategy event dispatch"
+                        )
 
                     processing_time = datetime.now(UTC)
                     typed_event = item if isinstance(item, MarketEvent) else None
@@ -612,7 +618,10 @@ class LiveEngine:
                     runtime_state=self._runtime_state,
                     recovery_action="inspect runtime diagnostics before restarting",
                 )
-            if not isinstance(error, asyncio.CancelledError):
+            if (
+                not isinstance(error, asyncio.CancelledError)
+                and self._terminal_failure_reason is None
+            ):
                 self._terminal_failure_reason = f"runtime:{type(error).__name__}"
             if isinstance(error, FeedContinuityError | FeedOverflowError):
                 if self._runtime_state is RuntimeState.RUNNING:

--- a/src/ml4t/live/safety.py
+++ b/src/ml4t/live/safety.py
@@ -2290,6 +2290,12 @@ class SafeBroker:
             self._set_state_snapshot(self._virtual_portfolio.positions, [])
             return
 
+        if getattr(self._broker, "is_connected", None) is False:
+            logger.warning(
+                "Retaining the last persisted broker snapshot because the broker is unhealthy"
+            )
+            return
+
         positions = getattr(self._broker, "positions", {})
         pending_orders = getattr(self._broker, "pending_orders", [])
         if isinstance(positions, dict) and isinstance(pending_orders, list):

--- a/tests/unit/test_alpaca_broker.py
+++ b/tests/unit/test_alpaca_broker.py
@@ -13,7 +13,7 @@ from alpaca.trading.enums import TimeInForce
 from alpaca.trading.requests import MarketOrderRequest
 from ml4t.backtest.types import Order, OrderSide, OrderStatus, OrderType, Position
 
-from ml4t.live.brokers.alpaca import AlpacaBroker
+from ml4t.live import AlpacaBroker, ExecutionModeError, LiveRiskConfig, SafeBroker
 
 
 class MockAlpacaAccount:
@@ -73,9 +73,14 @@ class MockAlpacaOrder:
         self.qty = qty
         self.side = side
         self.type = type
-        self.status = AlpacaOrderStatus.NEW if status == "new" else AlpacaOrderStatus.PENDING_NEW
+        self.status = {
+            "new": AlpacaOrderStatus.NEW,
+            "partially_filled": AlpacaOrderStatus.PARTIALLY_FILLED,
+            "filled": AlpacaOrderStatus.FILLED,
+        }.get(status, AlpacaOrderStatus.PENDING_NEW)
         self.filled_qty = filled_qty
         self.filled_avg_price = filled_avg_price
+        self.filled_at = datetime.now(UTC) if status == "filled" else None
         self.limit_price = limit_price
         self.stop_price = stop_price
         self.time_in_force = time_in_force
@@ -860,6 +865,120 @@ class TestAlpacaBrokerOrderSubmission:
         assert order2.order_id == "ML4T-2"
         assert broker._order_counter == 2
 
+    @pytest.mark.asyncio
+    async def test_rest_filled_order_refreshes_positions(self):
+        broker = AlpacaBroker(api_key="PKTEST", secret_key="SECRET")
+        broker._trading_client = MagicMock()
+        broker._connected = True
+        broker._trading_client.submit_order.return_value = MockAlpacaOrder(
+            status="filled",
+            filled_qty="2",
+            filled_avg_price="151.25",
+            qty="2",
+        )
+        broker._trading_client.get_all_positions.return_value = [
+            MockAlpacaPosition("AAPL", "2", "151.25")
+        ]
+
+        order = await broker.submit_order_async("AAPL", 2)
+
+        assert order.status is OrderStatus.FILLED
+        assert order.filled_quantity == 2
+        assert order.filled_price == 151.25
+        assert broker.positions["AAPL"].quantity == 2
+        broker._trading_client.get_all_positions.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_rest_partial_fill_preserves_evidence_and_refreshes_positions(self):
+        broker = AlpacaBroker(api_key="PKTEST", secret_key="SECRET")
+        broker._trading_client = MagicMock()
+        broker._connected = True
+        broker._trading_client.submit_order.return_value = MockAlpacaOrder(
+            status="partially_filled",
+            filled_qty="1",
+            filled_avg_price="151.25",
+            qty="2",
+        )
+        broker._trading_client.get_all_positions.return_value = [
+            MockAlpacaPosition("AAPL", "1", "151.25")
+        ]
+
+        order = await broker.submit_order_async("AAPL", 2)
+
+        assert order.status is OrderStatus.PENDING
+        assert order.filled_quantity == 1
+        assert order.filled_price == 151.25
+        assert broker.pending_orders == [order]
+        assert broker.positions["AAPL"].quantity == 1
+        broker._trading_client.get_all_positions.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_rest_fill_refresh_failure_preserves_acceptance_and_poison_snapshot(self):
+        broker = AlpacaBroker(api_key="PKTEST", secret_key="SECRET")
+        broker._trading_client = MagicMock()
+        broker._connected = True
+        broker._trading_client.submit_order.return_value = MockAlpacaOrder(
+            status="filled",
+            filled_qty="2",
+            filled_avg_price="151.25",
+            qty="2",
+        )
+        broker._trading_client.get_all_positions.side_effect = RuntimeError("venue unavailable")
+
+        order = await broker.submit_order_async("AAPL", 2)
+
+        assert order.status is OrderStatus.FILLED
+        assert order.filled_quantity == 2
+        assert broker.is_connected is False
+        with pytest.raises(RuntimeError, match="position state is unavailable"):
+            _ = broker.positions
+        with pytest.raises(RuntimeError, match="position state is unavailable"):
+            broker.get_position("AAPL")
+
+    @pytest.mark.asyncio
+    async def test_safe_broker_commits_accepted_fill_before_blocking_further_trades(self, tmp_path):
+        broker = AlpacaBroker(api_key="PKTEST", secret_key="SECRET")
+        broker._trading_client = MagicMock()
+        broker._trading_client._sandbox = True
+        broker._trading_client._base_url = BaseURL.TRADING_PAPER
+        broker._trading_client.submit_order.return_value = MockAlpacaOrder(
+            status="filled",
+            filled_qty="2",
+            filled_avg_price="151.25",
+            qty="2",
+        )
+        broker._trading_client.get_all_positions.side_effect = RuntimeError("venue unavailable")
+        broker._account_id = "PA-TEST"
+        broker._connected = True
+        safe = SafeBroker(
+            broker,
+            LiveRiskConfig(
+                execution_mode="paper",
+                state_file=str(tmp_path / "risk-state.json"),
+                max_position_value=None,
+                max_position_shares=None,
+                max_total_exposure=None,
+                max_positions=None,
+                max_order_value=None,
+                max_order_shares=None,
+                max_orders_per_minute=None,
+                max_daily_loss=None,
+                max_drawdown_pct=None,
+                max_price_deviation_pct=None,
+                max_data_staleness_seconds=None,
+                dedup_window_seconds=None,
+            ),
+        )
+
+        order = await safe.submit_order_async(
+            "AAPL", 2, order_type=OrderType.LIMIT, limit_price=151.25
+        )
+
+        assert order.status is OrderStatus.FILLED
+        assert safe._state.orders_placed == 1
+        with pytest.raises(ExecutionModeError, match="does not match"):
+            await safe.submit_order_async("AAPL", 2, order_type=OrderType.LIMIT, limit_price=151.25)
+
 
 class TestAlpacaBrokerOrderStatus:
     """Test suite for order status callbacks."""
@@ -912,6 +1031,10 @@ class TestAlpacaBrokerOrderStatus:
     async def test_on_trade_update_partial_fill(self):
         """Test partial fill callback updates status."""
         broker = AlpacaBroker(api_key="PKTEST", secret_key="SECRET")
+        broker._trading_client = MagicMock()
+        broker._trading_client.get_all_positions.return_value = [
+            MockAlpacaPosition("AAPL", "50", "150.25")
+        ]
         broker._connected = True
 
         pending_order = Order(
@@ -943,6 +1066,27 @@ class TestAlpacaBrokerOrderStatus:
         order = broker._pending_orders["ML4T-1"]
         assert order.status == OrderStatus.PENDING  # Still pending
         assert order.filled_quantity == 50
+        assert broker.positions["AAPL"].quantity == 50
+        broker._trading_client.get_all_positions.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_partial_fill_position_failure_poison_snapshot(self):
+        broker = tracked_order_broker()
+        broker._trading_client = MagicMock()
+        broker._trading_client.get_all_positions.side_effect = RuntimeError("venue unavailable")
+        partial_order = MockAlpacaOrder(
+            id="venue-1",
+            qty="10",
+            status="partially_filled",
+            filled_qty="5",
+            filled_avg_price="150.25",
+        )
+
+        await broker._on_trade_update(MockTradeUpdate("partial_fill", partial_order))
+
+        assert broker.is_connected is False
+        with pytest.raises(RuntimeError, match="order state is unavailable"):
+            _ = broker.positions
 
     @pytest.mark.asyncio
     async def test_on_trade_update_canceled(self):

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -550,6 +550,31 @@ async def test_run_with_data():
 
 
 @pytest.mark.asyncio
+async def test_broker_disconnect_blocks_the_next_strategy_callback() -> None:
+    broker = MockAsyncBroker()
+
+    class DisconnectingStrategy(RecordingStrategy):
+        def on_data(self, timestamp: datetime, data: dict, context: dict, wrapped: Any) -> None:
+            super().on_data(timestamp, data, context, wrapped)
+            broker._connected = False
+
+    event = (
+        datetime(2024, 1, 1, 9, 30, tzinfo=UTC),
+        {"AAPL": {"close": 150.0}},
+        {},
+    )
+    strategy = DisconnectingStrategy()
+    engine = LiveEngine(strategy, broker, MockDataFeed([event, event]))
+    await engine.connect()
+
+    with pytest.raises(RuntimeError, match="before the next strategy event dispatch"):
+        await engine.run()
+
+    assert len(strategy.on_data_calls) == 1
+    assert engine.stats["terminal_failure_reason"] == "broker_disconnected"
+
+
+@pytest.mark.asyncio
 async def test_typed_events_dispatch_by_kind_and_preserve_causal_context() -> None:
     strategy = RecordingStrategy()
     broker = MockAsyncBroker()


### PR DESCRIPTION
Closes #67

- retain cumulative fill evidence from initial REST partial fills
- refresh authoritative positions after REST and streamed material fills
- preserve accepted-order bookkeeping if refresh fails, poison stale position reads, and block further execution
- stop LiveEngine before another strategy event dispatch after broker health is lost

Verified locally with Ruff, ty, 984 tests (29 provider-dependent skips), strict MkDocs, and all pre-commit hooks.