### PR TITLE
fix: retain provider-specific qualification evidence

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -11,6 +11,12 @@ on:
         description: Successful qualification run that retained dist-CANDIDATE_SHA
         required: true
         type: string
+      extended-provider:
+        description: Provider needing a fresh six-hour soak, or all for initial qualification
+        required: true
+        default: none
+        type: choice
+        options: [none, alpaca, ib, okx, all]
 
 permissions: {}
 
@@ -152,10 +158,11 @@ jobs:
           --candidate "${{ github.workspace }}/paper-evidence/candidate.json"
           --checkout-root "${{ github.workspace }}"
           --output "${{ github.workspace }}/feed-evidence/okx.json"
-      - name: Run six-hour Alpaca, IB, and OKX soaks concurrently
+      - name: Run the selected six-hour provider soak
         id: provider-soaks
         if: >-
           ${{
+            inputs.extended-provider != 'none' &&
             steps.alpaca-exercise.outcome == 'success' &&
             steps.alpaca-restart.outcome == 'success' &&
             steps.ib-exercise.outcome == 'success' &&
@@ -176,12 +183,13 @@ jobs:
           -m scripts.qualification.qualify_provider_soaks
           --candidate "${{ github.workspace }}/paper-evidence/candidate.json"
           --checkout-root "${{ github.workspace }}"
+          --provider "${{ inputs.extended-provider }}"
           --alpaca-output "${{ github.workspace }}/paper-evidence/alpaca-soak.json"
           --ib-output "${{ github.workspace }}/paper-evidence/ib-soak.json"
           --okx-output "${{ github.workspace }}/feed-evidence/okx-soak.json"
       - name: Require complete redacted evidence for both paper providers
         id: evidence
-        if: ${{ always() }}
+        if: ${{ always() && inputs.extended-provider == 'all' }}
         continue-on-error: true
         run: >-
           "${{ runner.temp }}/paper-venv/bin/python"
@@ -196,7 +204,8 @@ jobs:
           --output paper-evidence/paper-qualification.json
       - name: Require the installed feed support contract and external evidence
         id: feed-evidence
-        if: ${{ always() }}
+        if: >-
+          ${{ always() && (inputs.extended-provider == 'okx' || inputs.extended-provider == 'all') }}
         continue-on-error: true
         run: >-
           cd "${{ runner.temp }}/paper-run" &&
@@ -230,17 +239,51 @@ jobs:
             paper-evidence/
             feed-evidence/
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
       - name: Require every provider qualification stage to pass
         if: ${{ always() }}
-        run: >-
+        env:
+          EXTENDED_PROVIDER: ${{ inputs.extended-provider }}
+        run: |
           test "${{ steps.alpaca-exercise.outcome }}" = success &&
           test "${{ steps.alpaca-restart.outcome }}" = success &&
           test "${{ steps.ib-exercise.outcome }}" = success &&
           test "${{ steps.ib-restart.outcome }}" = success &&
           test "${{ steps.okx-external.outcome }}" = success &&
-          test "${{ steps.provider-soaks.outcome }}" = success &&
-          test "${{ steps.evidence.outcome }}" = success &&
-          test "${{ steps.feed-evidence.outcome }}" = success &&
           test "${{ steps.evidence-scan.outcome }}" = success &&
           test "${{ steps.feed-evidence-scan.outcome }}" = success
+          if test "$EXTENDED_PROVIDER" != none; then
+            test "${{ steps.provider-soaks.outcome }}" = success
+          fi
+          if test "$EXTENDED_PROVIDER" = all; then
+            test "${{ steps.evidence.outcome }}" = success
+            test "${{ steps.feed-evidence.outcome }}" = success
+          elif test "$EXTENDED_PROVIDER" = okx; then
+            test "${{ steps.feed-evidence.outcome }}" = success
+          fi
+
+  archive:
+    name: Retain provider evidence
+    needs: paper
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: paper-${{ inputs.candidate-sha }}-${{ github.run_id }}
+          path: provider-evidence/
+      - name: Package the validated redacted evidence
+        run: zip -q -r provider-evidence.zip provider-evidence
+      - name: Publish durable provider evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "provider-evidence-${{ github.run_id }}"
+          provider-evidence.zip
+          --repo "${{ github.repository }}"
+          --target "${{ inputs.candidate-sha }}"
+          --title "Provider qualification evidence ${{ github.run_id }}"
+          --notes "Redacted provider qualification evidence retained for contract-based reuse."
+          --prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/stable-qualification.yml
 
   paper-evidence:
-    name: Require fresh paper qualification
+    name: Require exact exercises and reusable provider evidence
     runs-on: ubuntu-latest
     outputs:
       wheel_sha256: ${{ steps.paper.outputs.wheel_sha256 }}
@@ -50,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}
       - name: Match successful retained evidence to this commit
         id: paper
@@ -59,7 +60,6 @@ jobs:
           python scripts/qualification/check_paper_evidence.py
           --repository "${{ github.repository }}"
           --commit "${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}"
-          --max-age-days 7
           --github-output "$GITHUB_OUTPUT"
 
   publish:

--- a/docs/qualification.md
+++ b/docs/qualification.md
@@ -49,34 +49,46 @@ acknowledgement, reconnect reconciliation, replacement, cancellation, cleanup, a
 from a fresh process. IB accepts only the standard paper ports and an account identified by IB as a
 paper account. Alpaca accepts only the SDK's official paper endpoint in sandbox mode.
 
-After the order-lifecycle checks, each broker remains connected to its paper account for at least
-six continuous hours. Five-minute snapshots must preserve exact adapter-to-provider positions and
-pending orders, valid account metrics, connection state, and the initial account-state checksum.
-Each broker must complete one controlled reconnect, retain snapshot continuity, keep process RSS
-growth below 25 MiB, and disconnect within five seconds. Any unexpected disconnect, reconciliation
-change, invalid paper identity, or retained error fails the run.
+The order-lifecycle checks run for every candidate. Extended Alpaca, IB, and OKX soaks run
+independently. Set `extended-provider` to the provider whose contract changed, to `all` for initial
+qualification, or to `none` when all three current extended results remain applicable.
 
-The retained bundle contains counts and pass/fail state, not account or order identifiers. The
-release gate downloads and validates the bundle, requires both phases for both brokers, and returns
-the qualified wheel's SHA-256 digest. Before publication, the tag workflow compares that digest with
-the only wheel in its qualified distribution artifact. A successful workflow conclusion or artifact
-name is not sufficient by itself. The evidence must also remain within the release workflow's
-freshness interval.
+Each selected broker remains connected to its paper account for at least six continuous hours.
+Five-minute snapshots must preserve exact adapter-to-provider positions and pending orders, valid
+account metrics, connection state, and the initial account-state checksum. The broker must complete
+one controlled reconnect, retain snapshot continuity, keep process RSS growth below 25 MiB, and
+disconnect within five seconds. Any unexpected disconnect, reconciliation change, invalid paper
+identity, or retained error fails the run.
 
-The same workflow qualifies `OKXFundingFeed` against the public OKX service. It compares adapter
+Every extended report records a provider-contract identity. The identity hashes the provider
+adapter, qualification logic reached by that soak, the resolved provider dependency, and the Linux
+CPython 3.12 runtime contract. OKX also hashes the shared event and queue contracts reached by its
+feed. A changed identity invalidates only that provider's result. Documentation, CI metadata, and
+source code outside the extended provider path do not invalidate it.
+
+The workflow stores redacted evidence as a 90-day Actions artifact and as a durable prerelease
+asset named `provider-evidence-RUN_ID/provider-evidence.zip`. The release gate validates the exact
+candidate's short exercises, then selects a matching extended result for each provider from current
+or earlier runs. Evidence has no time-based expiry. Missing, malformed, or mismatched evidence fails
+closed. The Aug 10 run at `98c414e9d858427c31e1680faccdc8dca498bf6b` is the only legacy result
+accepted without an embedded identity; the verifier recomputes its narrower reviewed identity.
+
+The same workflow qualifies `OKXFundingFeed` against the public OKX service for every candidate. It compares adapter
 events with provider-native observations, observes consecutive complete candles across restart,
 rejects stale input, forces fail-closed overload, and requires shutdown within five seconds. The
-same installed wheel then runs for at least six continuous hours with five-minute event, queue, and
-RSS snapshots and one retained-state restart. The Alpaca, IB, and OKX sessions run concurrently so
-the workflow remains bounded by one six-hour interval. Every complete minute must remain
+selected OKX extended run then continues for at least six hours with five-minute event, queue, and
+RSS snapshots and one retained-state restart. Every complete minute must remain
 contiguous, final state must match a native OKX observation, RSS growth must remain below 25 MiB,
 and errors, rejections, or overflows fail the run. The retained feed bundle also proves that Alpaca,
 IB, DataBento, and generic CCXT feed construction requires `experimental=True` and records each
 adapter's missing guarantees. The release gate requires the paper and feed bundles to identify the
 same commit and wheel.
 
-Do not expose broker credentials to pull-request code. Do not substitute a run from another commit,
-reuse an artifact after a source or workflow change, or point IB qualification at a live port.
+IB Gateway or TWS authentication is an operator prerequisite. Once the paper session is
+authenticated, the self-hosted runner can execute the short check or selected soak without further
+operator input. IB does not support fully unattended login, so a changed IB contract may still wait
+for authentication. Do not expose broker credentials to pull-request code or point IB qualification
+at a live port.
 
 ## Retain Candidate Identity
 

--- a/scripts/qualification/check_paper_evidence.py
+++ b/scripts/qualification/check_paper_evidence.py
@@ -1,4 +1,4 @@
-"""Require fresh successful paper evidence for an exact candidate commit."""
+"""Require exact-candidate exercises and matching retained provider evidence."""
 
 from __future__ import annotations
 
@@ -25,8 +25,16 @@ _feeds = importlib.import_module("scripts.qualification.qualify_feeds")
 _paper = importlib.import_module("scripts.qualification.qualify_paper")
 FeedQualificationError = _feeds.FeedQualificationError
 validate_feed_bundle = _feeds.validate_feed_bundle
+validate_okx_report = _feeds.validate_okx_report
+validate_okx_soak_report = _feeds.validate_soak_report
 PaperQualificationError = _paper.PaperQualificationError
 validate_bundle = _paper.validate_bundle
+validate_provider_report = _paper.validate_provider_report
+validate_provider_soak_report = _paper.validate_provider_soak_report
+verify_candidate_manifest = _paper.verify_candidate_manifest
+_candidate_identity = _paper._candidate_identity
+_contracts = importlib.import_module("scripts.qualification.provider_contract")
+provider_contract_matches = _contracts.provider_contract_matches
 
 GITHUB_API = "https://api.github.com"
 
@@ -71,7 +79,7 @@ def fetch_bytes(url: str, token: str) -> bytes:
     request = urllib.request.Request(
         url,
         headers={
-            "Accept": "application/vnd.github+json",
+            "Accept": "application/octet-stream",
             "Authorization": f"Bearer {token}",
             "X-GitHub-Api-Version": "2022-11-28",
         },
@@ -81,74 +89,140 @@ def fetch_bytes(url: str, token: str) -> bytes:
         return response.read()
 
 
-def validate_evidence_archive(payload: bytes, expected_commit: str) -> dict[str, Any]:
-    """Validate the retained bundle rather than trusting workflow metadata alone."""
-    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
-        paper_matches = [
-            name for name in archive.namelist() if name.endswith("paper-qualification.json")
-        ]
-        feed_matches = [
-            name for name in archive.namelist() if name.endswith("feed-qualification.json")
-        ]
-        if len(paper_matches) != 1:
-            raise PaperQualificationError("paper artifact has no unique qualification bundle")
-        if len(feed_matches) != 1:
-            raise FeedQualificationError("paper artifact has no unique feed qualification bundle")
-        loaded = json.loads(archive.read(paper_matches[0]))
-        feed_loaded = json.loads(archive.read(feed_matches[0]))
+def _unique_json(archive: zipfile.ZipFile, suffix: str) -> dict[str, Any]:
+    matches = [name for name in archive.namelist() if name.endswith(suffix)]
+    if len(matches) != 1:
+        raise PaperQualificationError(f"paper artifact has no unique {suffix}")
+    loaded = json.loads(archive.read(matches[0]))
     if not isinstance(loaded, dict):
-        raise PaperQualificationError("paper qualification bundle is not a JSON object")
-    if not isinstance(feed_loaded, dict):
-        raise FeedQualificationError("feed qualification bundle is not a JSON object")
-    validate_bundle(loaded, expected_commit=expected_commit)
-    validate_feed_bundle(feed_loaded, expected_commit=expected_commit)
-    if feed_loaded["candidate"] != loaded["candidate"]:
-        raise FeedQualificationError("paper and feed bundles target different candidates")
+        raise PaperQualificationError(f"{suffix} is not a JSON object")
     return loaded
 
 
-def find_fresh_paper_run(
+def _optional_json(archive: zipfile.ZipFile, suffix: str) -> dict[str, Any] | None:
+    matches = [name for name in archive.namelist() if name.endswith(suffix)]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise PaperQualificationError(f"paper artifact has no unique {suffix}")
+    loaded = json.loads(archive.read(matches[0]))
+    if not isinstance(loaded, dict):
+        raise PaperQualificationError(f"{suffix} is not a JSON object")
+    return loaded
+
+
+def validate_evidence_archive(payload: bytes, expected_commit: str) -> dict[str, Any]:
+    """Validate exact-candidate exercises and any retained extended reports."""
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        manifest = _unique_json(archive, "candidate.json")
+        verify_candidate_manifest(manifest)
+        identity = _candidate_identity(manifest)
+        if identity["commit"] != expected_commit:
+            raise PaperQualificationError("paper artifact targets a different commit")
+        for provider in ("alpaca", "ib"):
+            for phase in ("exercise", "restart"):
+                validate_provider_report(
+                    _unique_json(archive, f"{provider}-{phase}.json"),
+                    identity,
+                    provider,
+                    phase,
+                )
+        validate_okx_report(_unique_json(archive, "okx.json"), manifest)
+        soaks: dict[str, dict[str, Any]] = {}
+        for provider, suffix in {
+            "alpaca": "alpaca-soak.json",
+            "ib": "ib-soak.json",
+            "okx": "okx-soak.json",
+        }.items():
+            report = _optional_json(archive, suffix)
+            if report is None:
+                continue
+            if provider == "okx":
+                validate_okx_soak_report(report, manifest)
+            else:
+                validate_provider_soak_report(report, identity, provider)
+            soaks[provider] = report
+    return {"candidate": identity, "soaks": soaks}
+
+
+def _archive_source(
+    *,
+    repository: str,
+    run: dict[str, Any],
+    token: str,
+    fetcher: Callable[[str, str], dict[str, Any]],
+) -> tuple[str, str] | None:
+    evidence_commit = str(run["head_sha"])
+    expected_name = f"paper-{evidence_commit}-{run['id']}"
+    artifacts = fetcher(run["artifacts_url"], token).get("artifacts", [])
+    matching = [
+        artifact
+        for artifact in artifacts
+        if artifact.get("name") == expected_name
+        and not artifact.get("expired", True)
+        and artifact.get("archive_download_url")
+    ]
+    if len(matching) == 1:
+        return expected_name, str(matching[0]["archive_download_url"])
+
+    release_url = f"{GITHUB_API}/repos/{repository}/releases/tags/provider-evidence-{run['id']}"
+    try:
+        release = fetcher(release_url, token)
+    except OSError:
+        return None
+    assets = [
+        asset
+        for asset in release.get("assets", [])
+        if asset.get("name") == "provider-evidence.zip" and asset.get("url")
+    ]
+    if len(assets) != 1:
+        return None
+    return f"provider-evidence-{run['id']}/provider-evidence.zip", str(assets[0]["url"])
+
+
+def find_paper_evidence(
     *,
     repository: str,
     commit: str,
     token: str,
-    max_age: timedelta,
-    now: datetime,
+    checkout_root: Path,
     fetcher: Callable[[str, str], dict[str, Any]] = fetch_json,
     downloader: Callable[[str, str], bytes] = fetch_bytes,
+    contract_matcher: Callable[..., bool] = provider_contract_matches,
 ) -> dict[str, Any] | None:
     query = urllib.parse.urlencode(
         {
             "event": "workflow_dispatch",
             "status": "success",
-            "head_sha": commit,
             "per_page": 100,
         }
     )
     runs_url = f"{GITHUB_API}/repos/{repository}/actions/workflows/paper.yml/runs?{query}"
     runs = fetcher(runs_url, token).get("workflow_runs", [])
+    candidate_evidence: dict[str, Any] | None = None
+    provider_evidence: dict[str, dict[str, Any]] = {}
     for run in sorted(runs, key=lambda item: item.get("created_at", ""), reverse=True):
-        if run.get("head_sha") != commit or run.get("conclusion") != "success":
+        evidence_commit = run.get("head_sha")
+        if (
+            not isinstance(evidence_commit, str)
+            or run.get("conclusion") != "success"
+            or run.get("status", "completed") != "completed"
+        ):
             continue
         created_at = _parse_time(run["created_at"])
-        if now - created_at > max_age or created_at > now + timedelta(minutes=5):
+        if created_at > datetime.now(UTC) + timedelta(minutes=5):
             continue
-        artifacts = fetcher(run["artifacts_url"], token).get("artifacts", [])
-        expected_name = f"paper-{commit}-{run['id']}"
-        matching = [
-            artifact
-            for artifact in artifacts
-            if artifact.get("name") == expected_name
-            and not artifact.get("expired", True)
-            and _parse_time(artifact["created_at"]) >= created_at
-            and artifact.get("archive_download_url")
-        ]
-        if len(matching) != 1:
+        source = _archive_source(
+            repository=repository,
+            run=run,
+            token=token,
+            fetcher=fetcher,
+        )
+        if source is None:
             continue
+        evidence_name, download_url = source
         try:
-            bundle = validate_evidence_archive(
-                downloader(str(matching[0]["archive_download_url"]), token), commit
-            )
+            archive = validate_evidence_archive(downloader(download_url, token), evidence_commit)
         except (
             PaperQualificationError,
             FeedQualificationError,
@@ -158,45 +232,59 @@ def find_fresh_paper_run(
             zipfile.BadZipFile,
         ):
             continue
-        bundle_created_at = _parse_time(bundle["generated_at"])
-        if bundle_created_at < created_at or bundle_created_at > now + timedelta(minutes=5):
-            continue
-        if bundle["passed"]:
-            return {
+        identity = archive["candidate"]
+        if evidence_commit == commit and candidate_evidence is None:
+            candidate_evidence = {
                 "run_id": run["id"],
                 "run_url": run.get("html_url"),
                 "created_at": run["created_at"],
-                "artifact": expected_name,
-                "qualification_run_id": bundle["candidate"]["qualification_run_id"],
-                "wheel_sha256": bundle["candidate"]["wheel_sha256"],
-                "sdist_sha256": bundle["candidate"]["sdist_sha256"],
+                "artifact": evidence_name,
+                "qualification_run_id": identity["qualification_run_id"],
+                "wheel_sha256": identity["wheel_sha256"],
+                "sdist_sha256": identity["sdist_sha256"],
             }
-    return None
+        for provider, report in archive["soaks"].items():
+            if provider in provider_evidence:
+                continue
+            if contract_matcher(
+                provider,
+                evidence_commit=evidence_commit,
+                candidate_commit=commit,
+                checkout_root=checkout_root,
+                reported_contract=report.get("provider_contract"),
+            ):
+                provider_evidence[provider] = {
+                    "run_id": run["id"],
+                    "run_url": run.get("html_url"),
+                    "commit": evidence_commit,
+                    "completed_at": report["completed_at"],
+                    "artifact": evidence_name,
+                }
+    if candidate_evidence is None or set(provider_evidence) != {"alpaca", "ib", "okx"}:
+        return None
+    return {**candidate_evidence, "providers": provider_evidence}
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository", required=True)
     parser.add_argument("--commit", required=True)
-    parser.add_argument("--max-age-days", type=int, default=7)
     parser.add_argument("--output")
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args()
     token = os.environ.get("GITHUB_TOKEN", "")
     if not token:
         raise RuntimeError("GITHUB_TOKEN is required to read workflow evidence")
-    evidence = find_fresh_paper_run(
+    evidence = find_paper_evidence(
         repository=args.repository,
         commit=args.commit,
         token=token,
-        max_age=timedelta(days=args.max_age_days),
-        now=datetime.now(UTC),
+        checkout_root=REPOSITORY_ROOT,
     )
     report = {
         "schema_version": 1,
         "repository": args.repository,
         "commit": args.commit,
-        "max_age_days": args.max_age_days,
         "evidence": evidence,
         "passed": evidence is not None,
     }

--- a/scripts/qualification/check_workflows.py
+++ b/scripts/qualification/check_workflows.py
@@ -489,11 +489,34 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     if retained_paths != {"paper-evidence/", "feed-evidence/"}:
         failures.append("paper qualification does not retain its evidence bundle")
 
+    archive_job = paper.get("jobs", {}).get("archive", {})
+    if _needs(archive_job) != {"paper"} or archive_job.get("runs-on") != "ubuntu-latest":
+        failures.append("provider evidence is not archived by a hosted job after qualification")
+    archive_text = json.dumps(archive_job, sort_keys=True)
+    if "secrets." in archive_text:
+        failures.append("provider evidence archival references a credential secret")
+    archive_downloads = _action_steps(archive_job, "actions/download-artifact")
+    if (
+        len(archive_downloads) != 1
+        or archive_downloads[0].get("with", {}).get("name")
+        != "paper-${{ inputs.candidate-sha }}-${{ github.run_id }}"
+    ):
+        failures.append("provider evidence archival does not download the current run artifact")
+    archive_run_text = _run_text(archive_job)
+    for required in (
+        'gh release create "provider-evidence-${{ github.run_id }}"',
+        '--target "${{ inputs.candidate-sha }}"',
+        "--prerelease",
+    ):
+        if required not in archive_run_text:
+            failures.append(f"provider evidence archival omits: {required}")
+
     allowed_job_writes = {
         ("release.yml", "publish"): {"id-token"},
         ("release.yml", "github-release"): {"contents"},
         ("release.yml", "recovery-publish"): {"id-token"},
         ("release.yml", "recovery-github-release"): {"contents"},
+        ("paper.yml", "archive"): {"contents"},
     }
     for workflow_name, workflow in workflows.items():
         for job_name, job in workflow.get("jobs", {}).items():

--- a/scripts/qualification/provider_contract.py
+++ b/scripts/qualification/provider_contract.py
@@ -1,0 +1,138 @@
+"""Build provider-specific identities for reusable extended qualification evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any
+
+PROVIDERS = ("alpaca", "ib", "okx")
+LEGACY_EVIDENCE_COMMITS = frozenset({"98c414e9d858427c31e1680faccdc8dca498bf6b"})
+RUNTIME_CONTRACT = {
+    "implementation": "CPython",
+    "python": "3.12",
+    "system": "Linux",
+    "machine": "x86_64",
+}
+
+_V1_PATHS = {
+    "alpaca": ("src/ml4t/live/brokers/alpaca.py",),
+    "ib": ("src/ml4t/live/brokers/ib.py",),
+    "okx": ("src/ml4t/live/feeds/okx_feed.py",),
+}
+_V2_PATHS = {
+    "alpaca": (*_V1_PATHS["alpaca"], "scripts/qualification/qualify_paper.py"),
+    "ib": (*_V1_PATHS["ib"], "scripts/qualification/qualify_paper.py"),
+    "okx": (
+        *_V1_PATHS["okx"],
+        "src/ml4t/live/feeds/events.py",
+        "src/ml4t/live/feeds/queue.py",
+        "scripts/qualification/qualify_feeds.py",
+    ),
+}
+_DEPENDENCIES = {"alpaca": "alpaca-py", "ib": "ib-async", "okx": "ccxt"}
+
+
+class ProviderContractError(RuntimeError):
+    """A provider contract cannot be computed or verified."""
+
+
+def _git_text(checkout_root: Path, ref: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=checkout_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ProviderContractError(f"provider contract input is unavailable: {path}")
+    return result.stdout
+
+
+def _dependency_version(lock_text: str, dependency: str) -> str:
+    lock = tomllib.loads(lock_text)
+    matches = {
+        package.get("version")
+        for package in lock.get("package", [])
+        if package.get("name") == dependency
+    }
+    if len(matches) != 1 or not all(isinstance(version, str) for version in matches):
+        raise ProviderContractError(
+            f"provider dependency has no unique resolved version: {dependency}"
+        )
+    return str(matches.pop())
+
+
+def provider_contract(
+    provider: str,
+    *,
+    checkout_root: Path,
+    ref: str = "HEAD",
+    schema_version: int = 2,
+) -> dict[str, Any]:
+    """Return a deterministic provider contract at a Git revision."""
+    if provider not in PROVIDERS:
+        raise ProviderContractError(f"unsupported provider: {provider}")
+    if schema_version not in {1, 2}:
+        raise ProviderContractError(f"unsupported provider contract schema: {schema_version}")
+    paths = _V1_PATHS[provider] if schema_version == 1 else _V2_PATHS[provider]
+    inputs = {
+        path: hashlib.sha256(_git_text(checkout_root, ref, path).encode()).hexdigest()
+        for path in paths
+    }
+    dependency = _DEPENDENCIES[provider]
+    payload = {
+        "schema_version": schema_version,
+        "provider": provider,
+        "inputs": inputs,
+        "dependency": {
+            "name": dependency,
+            "version": _dependency_version(_git_text(checkout_root, ref, "uv.lock"), dependency),
+        },
+        "runtime": RUNTIME_CONTRACT,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    return {**payload, "sha256": digest}
+
+
+def provider_contract_matches(
+    provider: str,
+    *,
+    evidence_commit: str,
+    candidate_commit: str,
+    checkout_root: Path,
+    reported_contract: dict[str, Any] | None,
+) -> bool:
+    """Return whether extended evidence still covers the candidate contract."""
+    if reported_contract is None:
+        if evidence_commit not in LEGACY_EVIDENCE_COMMITS:
+            return False
+        schema_version = 1
+    else:
+        schema_version = reported_contract.get("schema_version")
+        if schema_version != 2:
+            return False
+    try:
+        evidence = provider_contract(
+            provider,
+            checkout_root=checkout_root,
+            ref=evidence_commit,
+            schema_version=schema_version,
+        )
+        candidate = provider_contract(
+            provider,
+            checkout_root=checkout_root,
+            ref=candidate_commit,
+            schema_version=schema_version,
+        )
+    except ProviderContractError:
+        return False
+    if reported_contract is not None and reported_contract != evidence:
+        return False
+    return evidence["sha256"] == candidate["sha256"]

--- a/scripts/qualification/qualify_feeds.py
+++ b/scripts/qualification/qualify_feeds.py
@@ -25,6 +25,8 @@ _candidate_identity = _paper._candidate_identity
 _load_json = _paper._load_json
 _verify_installed_candidate = _paper._verify_installed_candidate
 _write_json = _paper._write_json
+_contracts = importlib.import_module("scripts.qualification.provider_contract")
+provider_contract = _contracts.provider_contract
 
 OKX_API = "https://www.okx.com/api/v5"
 OKX_SYMBOL = "BTC-USDT-SWAP"
@@ -453,9 +455,14 @@ async def qualify_okx_soak(candidate: dict[str, Any], checkout_root: Path) -> di
     rss_growth = max(snapshot["rss_bytes"] for snapshot in snapshots) - snapshots[0]["rss_bytes"]
     final_stats = feed.stats
     report = {
-        "schema_version": 1,
+        "schema_version": 2,
         "provider": "okx",
         "candidate": identity,
+        "provider_contract": provider_contract(
+            "okx",
+            checkout_root=checkout_root,
+            ref=str(identity["commit"]),
+        ),
         "started_at": started_at.isoformat(),
         "completed_at": datetime.now(UTC).isoformat(),
         "duration_seconds": round(duration, 3),
@@ -501,7 +508,10 @@ def validate_soak_report(report: dict[str, Any], candidate: dict[str, Any]) -> N
         "overflow_count",
         "passed",
     }
-    if set(report) != required or report.get("schema_version") != 1:
+    schema_version = report.get("schema_version")
+    if schema_version == 2:
+        required.add("provider_contract")
+    if set(report) != required or schema_version not in {1, 2}:
         raise FeedQualificationError("OKX soak report schema is invalid")
     if report.get("provider") != "okx" or report.get("candidate") != _candidate_identity(candidate):
         raise FeedQualificationError("OKX soak report targets a different provider or candidate")

--- a/scripts/qualification/qualify_paper.py
+++ b/scripts/qualification/qualify_paper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import importlib
 import importlib.metadata
 import json
 import math
@@ -21,6 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import psutil
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+_contracts = importlib.import_module("scripts.qualification.provider_contract")
+provider_contract = _contracts.provider_contract
 
 GITHUB_API = "https://api.github.com"
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -847,9 +855,14 @@ async def run_provider_soak(
         and error_count == 0
     )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "provider": provider,
         "candidate": identity,
+        "provider_contract": provider_contract(
+            provider,
+            checkout_root=checkout_root,
+            ref=str(identity["commit"]),
+        ),
         "started_at": started_at,
         "completed_at": datetime.now(UTC).isoformat(),
         "duration_seconds": duration_seconds,
@@ -980,7 +993,10 @@ def validate_provider_soak_report(
         "failure_type",
         "passed",
     }
-    if set(report) != required or report.get("schema_version") != 1:
+    schema_version = report.get("schema_version")
+    if schema_version == 2:
+        required.add("provider_contract")
+    if set(report) != required or schema_version not in {1, 2}:
         raise PaperQualificationError("provider soak report schema is invalid")
     if report.get("provider") != provider or report.get("candidate") != candidate_identity:
         raise PaperQualificationError("provider soak report targets a different candidate")

--- a/scripts/qualification/qualify_provider_soaks.py
+++ b/scripts/qualification/qualify_provider_soaks.py
@@ -12,14 +12,19 @@ from scripts.qualification.qualify_paper import _load_json, _write_json, run_pro
 
 
 async def qualify_provider_soaks(
-    *, candidate: dict[str, Any], checkout_root: Path
+    *, candidate: dict[str, Any], checkout_root: Path, providers: tuple[str, ...]
 ) -> tuple[dict[str, dict[str, Any]], list[str]]:
     tasks = {
-        "alpaca": run_provider_soak(
-            provider="alpaca", candidate=candidate, checkout_root=checkout_root
-        ),
-        "ib": run_provider_soak(provider="ib", candidate=candidate, checkout_root=checkout_root),
-        "okx": qualify_okx_soak(candidate, checkout_root),
+        provider: (
+            qualify_okx_soak(candidate, checkout_root)
+            if provider == "okx"
+            else run_provider_soak(
+                provider=provider,
+                candidate=candidate,
+                checkout_root=checkout_root,
+            )
+        )
+        for provider in providers
     }
     results = await asyncio.gather(*tasks.values(), return_exceptions=True)
     reports: dict[str, dict[str, Any]] = {}
@@ -41,10 +46,18 @@ def main() -> int:
     parser.add_argument("--alpaca-output", type=Path, required=True)
     parser.add_argument("--ib-output", type=Path, required=True)
     parser.add_argument("--okx-output", type=Path, required=True)
+    parser.add_argument(
+        "--provider",
+        choices=("alpaca", "ib", "okx", "all"),
+        default="all",
+    )
     args = parser.parse_args()
+    providers = ("alpaca", "ib", "okx") if args.provider == "all" else (args.provider,)
     reports, failures = asyncio.run(
         qualify_provider_soaks(
-            candidate=_load_json(args.candidate), checkout_root=args.checkout_root
+            candidate=_load_json(args.candidate),
+            checkout_root=args.checkout_root,
+            providers=providers,
         )
     )
     outputs = {
@@ -57,7 +70,7 @@ def main() -> int:
     if failures:
         print("provider soaks: FAIL (" + ", ".join(failures) + ")")
         return 1
-    print("provider soaks: PASS (alpaca, ib, okx)")
+    print("provider soaks: PASS (" + ", ".join(providers) + ")")
     return 0
 
 

--- a/tests/unit/test_paper_evidence.py
+++ b/tests/unit/test_paper_evidence.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import urllib.request
 import zipfile
 from pathlib import Path
+
+import pytest
 
 from scripts.qualification.check_paper_evidence import (
     _ArtifactRedirectHandler,
@@ -380,6 +383,14 @@ def test_artifact_redirect_drops_github_credentials_on_host_change() -> None:
 def test_legacy_ib_soak_remains_valid_while_changed_providers_do_not() -> None:
     repository = Path(__file__).resolve().parents[2]
     candidate = "HEAD"
+    history_available = subprocess.run(
+        ["git", "cat-file", "-e", f"{LEGACY_COMMIT}^{{commit}}"],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+    )
+    if history_available.returncode != 0:
+        pytest.skip("legacy provider evidence check requires the repository's full Git history")
 
     assert provider_contract_matches(
         "ib",

--- a/tests/unit/test_paper_evidence.py
+++ b/tests/unit/test_paper_evidence.py
@@ -4,13 +4,18 @@ import io
 import json
 import urllib.request
 import zipfile
-from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from scripts.qualification.check_paper_evidence import (
     _ArtifactRedirectHandler,
     fetch_bytes,
-    find_fresh_paper_run,
+    find_paper_evidence,
 )
+from scripts.qualification.provider_contract import (
+    provider_contract,
+    provider_contract_matches,
+)
+from scripts.qualification.qualify_feeds import REQUIRED_STEPS
 from scripts.qualification.qualify_paper import (
     EXERCISE_STEPS,
     RESTART_STEPS,
@@ -18,15 +23,22 @@ from scripts.qualification.qualify_paper import (
     SOAK_SNAPSHOT_INTERVAL_SECONDS,
 )
 
-NOW = datetime(2026, 8, 8, 20, tzinfo=UTC)
 COMMIT = "a" * 40
+LEGACY_COMMIT = "98c414e9d858427c31e1680faccdc8dca498bf6b"
 
 
-def _fetcher(created_at: str, *, conclusion: str = "success", expired: bool = False):
+def _fetcher(
+    created_at: str,
+    *,
+    conclusion: str = "success",
+    expired: bool = False,
+    release: bool = False,
+):
     run = {
         "id": 42,
         "head_sha": COMMIT,
         "conclusion": conclusion,
+        "status": "completed",
         "created_at": created_at,
         "artifacts_url": "https://api.github.test/artifacts",
         "html_url": "https://github.test/run/42",
@@ -44,6 +56,19 @@ def _fetcher(created_at: str, *, conclusion: str = "success", expired: bool = Fa
                         "archive_download_url": "https://api.github.test/archive/42",
                     }
                 ]
+            }
+        if "/releases/tags/" in url:
+            return {
+                "assets": (
+                    [
+                        {
+                            "name": "provider-evidence.zip",
+                            "url": "https://api.github.test/release-asset/42",
+                        }
+                    ]
+                    if release
+                    else []
+                )
             }
         return {"workflow_runs": [run]}
 
@@ -138,6 +163,84 @@ def _soak_report(provider: str, commit: str) -> dict:
     }
 
 
+def _manifest(commit: str) -> dict:
+    return {
+        "schema_version": 1,
+        "repository": "ml4t/live",
+        "commit": commit,
+        "qualification_run_id": 41,
+        "version": "0.1.0",
+        "wheel": {"filename": "ml4t_live-0.1.0-py3-none-any.whl", "sha256": "b" * 64},
+        "sdist": {"filename": "ml4t_live-0.1.0.tar.gz", "sha256": "c" * 64},
+        "passed": True,
+    }
+
+
+def _okx_report(commit: str) -> dict:
+    return {
+        "schema_version": 1,
+        "provider": "okx",
+        "candidate": _soak_report("alpaca", commit)["candidate"],
+        "started_at": "2026-08-07T20:00:00+00:00",
+        "completed_at": "2026-08-07T20:02:00+00:00",
+        "endpoint": {
+            "authentication": "public",
+            "host": "www.okx.com",
+            "instrument_type": "SWAP",
+            "identity_verified": True,
+        },
+        "steps_passed": sorted(REQUIRED_STEPS),
+        "event_kinds": ["bar", "funding"],
+        "complete_interval_seconds": 60,
+        "native_comparison_exact": True,
+        "reconnect_continuity": True,
+        "stale_rejected": True,
+        "overload": {"failed_closed": True, "overflow_count": 1, "retained_occupancy": 0},
+        "maximum_shutdown_seconds": 0.1,
+        "passed": True,
+    }
+
+
+def _okx_soak_report(commit: str) -> dict:
+    report = {
+        "schema_version": 1,
+        "provider": "okx",
+        "candidate": _soak_report("alpaca", commit)["candidate"],
+        "started_at": "2026-08-07T20:00:00+00:00",
+        "completed_at": "2026-08-08T02:00:01+00:00",
+        "duration_seconds": 21_600.1,
+        "snapshot_interval_seconds": 300,
+        "snapshots": [
+            {
+                "elapsed_seconds": index * 300,
+                "rss_bytes": 100_000_000,
+                "event_count": index + 1,
+                "complete_bar_count": index + 1,
+                "funding_count": 1,
+                "error_count": 0,
+                "rejected_count": 0,
+                "overflow_count": 0,
+                "queue_high_watermark": 2,
+            }
+            for index in range(73)
+        ],
+        "event_count": 361,
+        "complete_bar_count": 360,
+        "funding_count": 1,
+        "event_checksum": "d" * 64,
+        "reconnect_count": 1,
+        "continuity_gap_count": 0,
+        "native_final_reconciliation": True,
+        "rss_growth_bytes": 0,
+        "maximum_shutdown_seconds": 0.1,
+        "error_count": 0,
+        "rejected_count": 0,
+        "overflow_count": 0,
+        "passed": True,
+    }
+    return report
+
+
 def _archive(commit: str = COMMIT) -> bytes:
     bundle = {
         "schema_version": 1,
@@ -159,6 +262,19 @@ def _archive(commit: str = COMMIT) -> bytes:
     }
     payload = io.BytesIO()
     with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("paper-evidence/candidate.json", json.dumps(_manifest(commit)))
+        for provider in ("alpaca", "ib"):
+            for phase in ("exercise", "restart"):
+                archive.writestr(
+                    f"paper-evidence/{provider}-{phase}.json",
+                    json.dumps(_report(provider, phase, commit)),
+                )
+            archive.writestr(
+                f"paper-evidence/{provider}-soak.json",
+                json.dumps(_soak_report(provider, commit)),
+            )
+        archive.writestr("feed-evidence/okx.json", json.dumps(_okx_report(commit)))
+        archive.writestr("feed-evidence/okx-soak.json", json.dumps(_okx_soak_report(commit)))
         archive.writestr("paper-qualification.json", json.dumps(bundle))
         archive.writestr(
             "feed-qualification.json",
@@ -198,9 +314,12 @@ def _archive(commit: str = COMMIT) -> bytes:
     return payload.getvalue()
 
 
-def _downloader(payload: bytes = _archive()):
+def _downloader(
+    payload: bytes = _archive(),
+    expected_url: str = "https://api.github.test/archive/42",
+):
     def download(url: str, token: str) -> bytes:
-        assert url == "https://api.github.test/archive/42"
+        assert url == expected_url
         assert token == "token"
         return payload
 
@@ -220,7 +339,7 @@ def test_artifact_download_uses_github_json_media_type(monkeypatch) -> None:
 
     class Opener:
         def open(self, request, *, timeout: int):
-            assert request.get_header("Accept") == "application/vnd.github+json"
+            assert request.get_header("Accept") == "application/octet-stream"
             assert timeout == 30
             return Response()
 
@@ -258,18 +377,60 @@ def test_artifact_redirect_drops_github_credentials_on_host_change() -> None:
     assert redirected.get_header("Accept") is None
 
 
-def test_exact_fresh_successful_paper_evidence_passes() -> None:
-    evidence = find_fresh_paper_run(
+def test_legacy_ib_soak_remains_valid_while_changed_providers_do_not() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    candidate = "HEAD"
+
+    assert provider_contract_matches(
+        "ib",
+        evidence_commit=LEGACY_COMMIT,
+        candidate_commit=candidate,
+        checkout_root=repository,
+        reported_contract=None,
+    )
+    for provider in ("alpaca", "okx"):
+        assert not provider_contract_matches(
+            provider,
+            evidence_commit=LEGACY_COMMIT,
+            candidate_commit=candidate,
+            checkout_root=repository,
+            reported_contract=None,
+        )
+
+
+def test_reported_provider_contract_must_match_its_source_revision() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    contract = provider_contract("ib", checkout_root=repository)
+
+    assert provider_contract_matches(
+        "ib",
+        evidence_commit="HEAD",
+        candidate_commit="HEAD",
+        checkout_root=repository,
+        reported_contract=contract,
+    )
+    assert not provider_contract_matches(
+        "ib",
+        evidence_commit="HEAD",
+        candidate_commit="HEAD",
+        checkout_root=repository,
+        reported_contract={**contract, "sha256": "0" * 64},
+    )
+
+
+def test_exact_candidate_and_matching_provider_evidence_passes() -> None:
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-08-07T20:00:00Z"),
         downloader=_downloader(),
+        contract_matcher=lambda *_args, **_kwargs: True,
     )
 
-    assert evidence == {
+    assert evidence is not None
+    assert {key: value for key, value in evidence.items() if key != "providers"} == {
         "run_id": 42,
         "run_url": "https://github.test/run/42",
         "created_at": "2026-08-07T20:00:00Z",
@@ -278,59 +439,89 @@ def test_exact_fresh_successful_paper_evidence_passes() -> None:
         "wheel_sha256": "b" * 64,
         "sdist_sha256": "c" * 64,
     }
+    assert set(evidence["providers"]) == {"alpaca", "ib", "okx"}
 
 
-def test_stale_paper_evidence_fails() -> None:
-    evidence = find_fresh_paper_run(
+def test_age_does_not_invalidate_matching_provider_evidence() -> None:
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-07-01T20:00:00Z"),
         downloader=_downloader(),
+        contract_matcher=lambda *_args, **_kwargs: True,
+    )
+
+    assert evidence is not None
+
+
+def test_changed_provider_contract_fails_closed() -> None:
+    evidence = find_paper_evidence(
+        repository="ml4t/live",
+        commit=COMMIT,
+        token="token",
+        checkout_root=Path("."),
+        fetcher=_fetcher("2026-08-07T20:00:00Z"),
+        downloader=_downloader(),
+        contract_matcher=lambda provider, **_kwargs: provider != "ib",
     )
 
     assert evidence is None
 
 
 def test_expired_paper_artifact_fails() -> None:
-    evidence = find_fresh_paper_run(
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-08-07T20:00:00Z", expired=True),
         downloader=_downloader(),
+        contract_matcher=lambda *_args, **_kwargs: True,
     )
 
     assert evidence is None
 
 
-def test_wrong_commit_inside_retained_artifact_fails() -> None:
-    evidence = find_fresh_paper_run(
+def test_durable_release_asset_replaces_an_expired_actions_artifact() -> None:
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
+        fetcher=_fetcher("2026-08-07T20:00:00Z", expired=True, release=True),
+        downloader=_downloader(expected_url="https://api.github.test/release-asset/42"),
+        contract_matcher=lambda *_args, **_kwargs: True,
+    )
+
+    assert evidence is not None
+    assert evidence["artifact"] == "provider-evidence-42/provider-evidence.zip"
+
+
+def test_wrong_commit_inside_retained_artifact_fails() -> None:
+    evidence = find_paper_evidence(
+        repository="ml4t/live",
+        commit=COMMIT,
+        token="token",
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-08-07T20:00:00Z"),
         downloader=_downloader(_archive("c" * 40)),
+        contract_matcher=lambda *_args, **_kwargs: True,
     )
 
     assert evidence is None
 
 
 def test_malformed_retained_artifact_fails() -> None:
-    evidence = find_fresh_paper_run(
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-08-07T20:00:00Z"),
         downloader=_downloader(b"not a zip"),
+        contract_matcher=lambda *_args, **_kwargs: True,
     )
 
     assert evidence is None
@@ -341,14 +532,14 @@ def test_missing_feed_qualification_fails() -> None:
     with zipfile.ZipFile(payload, "w") as archive:
         archive.writestr("paper-qualification.json", "{}")
 
-    evidence = find_fresh_paper_run(
+    evidence = find_paper_evidence(
         repository="ml4t/live",
         commit=COMMIT,
         token="token",
-        max_age=timedelta(days=7),
-        now=NOW,
+        checkout_root=Path("."),
         fetcher=_fetcher("2026-08-07T20:00:00Z"),
         downloader=_downloader(payload.getvalue()),
+        contract_matcher=lambda *_args, **_kwargs: True,
     )
 
     assert evidence is None

--- a/tests/unit/test_paper_qualification.py
+++ b/tests/unit/test_paper_qualification.py
@@ -450,6 +450,11 @@ async def test_provider_soak_runs_continuously_and_reconnects_once(
     monkeypatch.setattr(paper_qualification, "_build_broker", lambda _provider: broker)
     monkeypatch.setattr(paper_qualification, "_snapshot", fake_snapshot)
     monkeypatch.setattr(paper_qualification, "_provider_state_checksum", lambda *_args: "d" * 64)
+    monkeypatch.setattr(
+        paper_qualification,
+        "provider_contract",
+        lambda *_args, **_kwargs: {"schema_version": 2, "sha256": "e" * 64},
+    )
 
     report = await run_provider_soak(
         provider="alpaca", candidate=_candidate(), checkout_root=tmp_path


### PR DESCRIPTION
Closes #66.

Keep exact-candidate lifecycle exercises on every release while reusing a six-hour provider soak until that provider contract changes. The fingerprint covers adapter code, shared qualification logic, the resolved provider dependency, and runtime identity. Evidence is archived as a durable prerelease asset after successful qualification.

IB Gateway authentication remains an operator prerequisite; after login, the selected provider job runs unattended.