### PR TITLE
fix: exclude evidence tags from package versions

### DIFF
--- a/.github/workflows/stable-qualification.yml
+++ b/.github/workflows/stable-qualification.yml
@@ -161,6 +161,15 @@ jobs:
           version: ${{ env.UV_VERSION }}
       - run: uv python install 3.12
       - run: uv sync --python 3.12 --all-extras --dev --locked
+      - name: Verify non-release tags cannot set the package version
+        run: |
+          env -u SETUPTOOLS_SCM_PRETEND_VERSION uv build \
+            --wheel \
+            --out-dir "${RUNNER_TEMP}/vcs-version" \
+            --build-constraints build-constraints.txt
+          uv run python scripts/qualification/verify_vcs_version.py \
+            --artifacts-dir "${RUNNER_TEMP}/vcs-version" \
+            --expected-version "${SETUPTOOLS_SCM_PRETEND_VERSION}"
       - name: Build from the fixed commit timestamp
         run: |
           export SOURCE_DATE_EPOCH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+tag-pattern = "^v(?P<version>.+)$"
+
+[tool.hatch.version.raw-options]
+git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*"]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/ml4t/live/_version.py"

--- a/scripts/qualification/verify_vcs_version.py
+++ b/scripts/qualification/verify_vcs_version.py
@@ -1,0 +1,59 @@
+"""Verify that an unforced VCS build derives from the intended package tag series."""
+
+from __future__ import annotations
+
+import argparse
+import email
+import zipfile
+from pathlib import Path
+
+from packaging.version import Version
+
+
+def wheel_version(artifacts_directory: Path) -> str:
+    """Read the version from exactly one wheel."""
+    wheels = sorted(artifacts_directory.glob("*.whl"))
+    if len(wheels) != 1:
+        raise ValueError("VCS version check requires exactly one wheel")
+    with zipfile.ZipFile(wheels[0]) as archive:
+        metadata_files = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise ValueError("VCS version wheel has no unique METADATA file")
+        version = email.message_from_bytes(archive.read(metadata_files[0])).get("Version")
+    if not version:
+        raise ValueError("VCS version wheel has no version")
+    return version
+
+
+def vcs_version_failure(version_text: str, expected_version: str) -> str | None:
+    """Return why an unforced build is outside its intended release series."""
+    version = Version(version_text)
+    expected = Version(expected_version)
+    if version.base_version != expected.base_version:
+        return f"VCS version {version} is outside release series {expected.base_version}"
+    if version != expected and not version.is_devrelease:
+        return f"VCS version {version} is neither {expected} nor a development build"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--expected-version", required=True)
+    args = parser.parse_args()
+    try:
+        version = wheel_version(args.artifacts_dir)
+        failure = vcs_version_failure(version, args.expected_version)
+    except (ValueError, zipfile.BadZipFile) as error:
+        version = "unavailable"
+        failure = str(error)
+    print(f"VCS package version: {'PASS' if failure is None else 'FAIL'} ({version})")
+    if failure:
+        print(f"- {failure}")
+    return int(failure is not None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_vcs_version.py
+++ b/tests/unit/test_vcs_version.py
@@ -1,0 +1,42 @@
+"""Tests for unforced VCS package-version validation."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.qualification.verify_vcs_version import vcs_version_failure, wheel_version
+
+
+def _wheel(directory: Path, version: str) -> Path:
+    path = directory / f"ml4t_live-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"ml4t_live-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.4\nName: ml4t-live\nVersion: {version}\n",
+        )
+    return path
+
+
+@pytest.mark.parametrize("version", ("0.1.1", "0.1.1.dev10+gf3135b8"))
+def test_expected_release_series_passes(tmp_path: Path, version: str) -> None:
+    assert vcs_version_failure(version, "0.1.1") is None
+
+
+@pytest.mark.parametrize("version", ("31362844984.dev10", "0.1.2.dev1", "0.1.1.post1"))
+def test_other_tag_series_and_nondevelopment_versions_fail(version: str) -> None:
+    assert vcs_version_failure(version, "0.1.1") is not None
+
+
+def test_wheel_metadata_version_is_read(tmp_path: Path) -> None:
+    _wheel(tmp_path, "0.1.1.dev10")
+    assert wheel_version(tmp_path) == "0.1.1.dev10"
+
+
+def test_wheel_inventory_must_be_unique(tmp_path: Path) -> None:
+    _wheel(tmp_path, "0.1.1")
+    _wheel(tmp_path, "0.1.1.dev1")
+    with pytest.raises(ValueError, match="exactly one wheel"):
+        wheel_version(tmp_path)


### PR DESCRIPTION
Closes #70.

Restrict Hatch VCS discovery to `v*` package tags so durable provider-evidence releases cannot become distribution versions. Stable qualification now performs an unforced wheel build and verifies that its metadata remains in the intended `0.1.1` release series.