### PR TITLE
Fix release recovery after the v0.1.1 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,24 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.9"
+      - run: uv python install 3.12
+      - name: Create a clean paper evidence runtime
+        id: paper-runtime
+        run: |
+          uv venv --clear --python 3.12 "${RUNNER_TEMP}/paper-evidence-venv"
+          uv pip install \
+            --python "${RUNNER_TEMP}/paper-evidence-venv/bin/python" \
+            "psutil==7.2.2"
       - name: Match successful retained evidence to this commit
         id: paper
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
-          python scripts/qualification/check_paper_evidence.py
+          "${RUNNER_TEMP}/paper-evidence-venv/bin/python"
+          scripts/qualification/check_paper_evidence.py
           --repository "${{ github.repository }}"
           --commit "${{ github.event_name == 'workflow_dispatch' && inputs.candidate-sha || github.sha }}"
           --github-output "$GITHUB_OUTPUT"

--- a/scripts/qualification/check_workflows.py
+++ b/scripts/qualification/check_workflows.py
@@ -283,6 +283,33 @@ def paper_runtime_failures(paper_job: dict[str, Any]) -> list[str]:
     return failures
 
 
+def release_paper_runtime_failures(paper_job: dict[str, Any]) -> list[str]:
+    """Reject a release evidence gate that depends on ambient runner packages."""
+    steps = _steps(paper_job)
+    indexed = {step.get("id"): (index, step) for index, step in enumerate(steps) if step.get("id")}
+    required = ("paper-runtime", "paper")
+    if any(step_id not in indexed for step_id in required):
+        return ["release paper evidence does not define its clean runtime and gate steps"]
+
+    runtime_index, runtime = indexed["paper-runtime"]
+    paper_index, paper = indexed["paper"]
+    failures = []
+    if runtime_index >= paper_index:
+        failures.append("release paper evidence does not prepare its runtime before validation")
+
+    runtime_text = str(runtime.get("run", ""))
+    paper_python = '"${RUNNER_TEMP}/paper-evidence-venv/bin/python"'
+    if "uv venv --clear --python 3.12" not in runtime_text:
+        failures.append("release paper evidence does not create a clean Python 3.12 environment")
+    if paper_python not in runtime_text or '"psutil==7.2.2"' not in runtime_text:
+        failures.append("release paper evidence does not install its pinned runtime dependency")
+    if not str(paper.get("run", "")).startswith(
+        f"{paper_python} scripts/qualification/check_paper_evidence.py"
+    ):
+        failures.append("release paper evidence does not use the clean validation environment")
+    return failures
+
+
 def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     paths = sorted(root.glob("*.yml"))
     workflows = {path.name: load_workflow(path) for path in paths}
@@ -405,6 +432,9 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     ):
         failures.append("release recovery does not require the candidate, source run, and tag")
     failures.extend(promotion_failures(qualification, release))
+    failures.extend(
+        release_paper_runtime_failures(release.get("jobs", {}).get("paper-evidence", {}))
+    )
     publish_job = release.get("jobs", {}).get("publish", {})
     publish_download_names = {
         step.get("with", {}).get("name")

--- a/scripts/qualification/verify_vcs_version.py
+++ b/scripts/qualification/verify_vcs_version.py
@@ -31,10 +31,16 @@ def vcs_version_failure(version_text: str, expected_version: str) -> str | None:
     """Return why an unforced build is outside its intended release series."""
     version = Version(version_text)
     expected = Version(expected_version)
-    if version.base_version != expected.base_version:
-        return f"VCS version {version} is outside release series {expected.base_version}"
-    if version != expected and not version.is_devrelease:
+    next_patch = Version(f"{expected.major}.{expected.minor}.{expected.micro + 1}")
+    if version == expected:
+        return None
+    if not version.is_devrelease:
         return f"VCS version {version} is neither {expected} nor a development build"
+    if Version(version.base_version) not in {expected, next_patch}:
+        return (
+            f"VCS version {version} is outside release transition "
+            f"{expected.base_version} to {next_patch.base_version}"
+        )
     return None
 
 

--- a/tests/unit/test_vcs_version.py
+++ b/tests/unit/test_vcs_version.py
@@ -20,13 +20,19 @@ def _wheel(directory: Path, version: str) -> Path:
     return path
 
 
-@pytest.mark.parametrize("version", ("0.1.1", "0.1.1.dev10+gf3135b8"))
-def test_expected_release_series_passes(tmp_path: Path, version: str) -> None:
+@pytest.mark.parametrize(
+    "version",
+    ("0.1.1", "0.1.1.dev10+gf3135b8", "0.1.2.dev1+gf69079b"),
+)
+def test_expected_release_transition_passes(version: str) -> None:
     assert vcs_version_failure(version, "0.1.1") is None
 
 
-@pytest.mark.parametrize("version", ("31362844984.dev10", "0.1.2.dev1", "0.1.1.post1"))
-def test_other_tag_series_and_nondevelopment_versions_fail(version: str) -> None:
+@pytest.mark.parametrize(
+    "version",
+    ("31362844984.dev10", "0.1.3.dev1", "0.2.0.dev1", "0.1.1.post1", "0.1.2"),
+)
+def test_other_tag_series_and_release_versions_fail(version: str) -> None:
     assert vcs_version_failure(version, "0.1.1") is not None
 
 

--- a/tests/unit/test_workflow_policy.py
+++ b/tests/unit/test_workflow_policy.py
@@ -11,6 +11,7 @@ from scripts.qualification.check_workflows import (
     paper_runtime_failures,
     paper_soak_failures,
     promotion_failures,
+    release_paper_runtime_failures,
     release_recovery_failures,
     validate_workflows,
 )
@@ -52,6 +53,28 @@ def test_paper_qualification_uses_a_clean_explicit_runtime() -> None:
     assert any(
         "pinned runtime dependency" in failure for failure in paper_runtime_failures(seeded_job)
     )
+
+
+@pytest.mark.parametrize("mutation", ["dependency", "interpreter"])
+def test_release_paper_evidence_uses_a_clean_explicit_runtime(mutation: str) -> None:
+    release = load_workflow(WORKFLOW_ROOT / "release.yml")
+    paper_job = release["jobs"]["paper-evidence"]
+
+    assert release_paper_runtime_failures(paper_job) == []
+
+    seeded_job = deepcopy(paper_job)
+    if mutation == "dependency":
+        runtime = next(step for step in seeded_job["steps"] if step.get("id") == "paper-runtime")
+        runtime["run"] = str(runtime["run"]).replace('"psutil==7.2.2"', "")
+        expected = "pinned runtime dependency"
+    else:
+        paper = next(step for step in seeded_job["steps"] if step.get("id") == "paper")
+        paper["run"] = str(paper["run"]).replace(
+            '"${RUNNER_TEMP}/paper-evidence-venv/bin/python"', "python"
+        )
+        expected = "clean validation environment"
+
+    assert any(expected in failure for failure in release_paper_runtime_failures(seeded_job))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #74.\nCloses #76.\n\nThe v0.1.1 tag run failed closed before publication because its paper-evidence job used the hosted runner system Python without `psutil`. This change gives the release and recovery evidence gate a clean Python 3.12 environment with pinned `psutil==7.2.2`, runs the checker through that interpreter, and extends workflow policy tests to reject removal of either binding.\n\nCreating the exact release tag also exposed a post-release CI defect: descendant pull requests correctly derive `0.1.2.devN`, while the VCS policy accepted only the `0.1.1` series. The focused version check now accepts the exact release, pre-tag development builds, and the immediate next patch development series while rejecting unrelated, later, minor, post, and unqualified release versions. Exact release artifact identity is unchanged.\n\nVerified:\n- reproduced both failures in Actions runs 34035391684 and 34035842739\n- focused workflow and VCS tests pass\n- exact evidence checker passes in a fresh venv containing only pinned psutil\n- an unforced branch build derives `0.1.2.dev1` and passes the corrected transition policy\n- workflow policy and pre-commit checks pass