### PR TITLE
test: honor configured release candidate version

### DIFF
--- a/tests/unit/test_artifact_qualification.py
+++ b/tests/unit/test_artifact_qualification.py
@@ -79,7 +79,7 @@ def test_metadata_contract_accepts_declared_stable_candidate() -> None:
         project = tomllib.load(stream)["project"]
     message = email.message.Message()
     message["Name"] = "ml4t-live"
-    message["Version"] = "0.1.1"
+    message["Version"] = qualify_artifacts.CANDIDATE_VERSION
     message["Requires-Python"] = ">=3.12"
     message["License-Expression"] = "MIT"
     message["Summary"] = EXPECTED_DESCRIPTION
@@ -93,7 +93,7 @@ def test_metadata_contract_accepts_declared_stable_candidate() -> None:
     for dependency in project["dependencies"]:
         message["Requires-Dist"] = dependency
 
-    assert validate_metadata(message, project) == "0.1.1"
+    assert validate_metadata(message, project) == qualify_artifacts.CANDIDATE_VERSION
 
 
 def test_metadata_contract_rejects_noncanonical_identity() -> None:
@@ -101,7 +101,7 @@ def test_metadata_contract_rejects_noncanonical_identity() -> None:
         project = tomllib.load(stream)["project"]
     message = email.message.Message()
     message["Name"] = "ml4t-live"
-    message["Version"] = "0.1.1"
+    message["Version"] = qualify_artifacts.CANDIDATE_VERSION
     message["Requires-Python"] = ">=3.12"
     message["License-Expression"] = "MIT"
     message["Summary"] = "Generic live trading package"
@@ -124,7 +124,7 @@ def test_metadata_contract_rejects_development_build_of_stable_candidate() -> No
         project = tomllib.load(stream)["project"]
     message = email.message.Message()
     message["Name"] = "ml4t-live"
-    message["Version"] = "0.1.1.dev1"
+    message["Version"] = f"{qualify_artifacts.CANDIDATE_VERSION}.dev1"
     message["Requires-Python"] = ">=3.12"
     message["License-Expression"] = "MIT"
     message["Summary"] = EXPECTED_DESCRIPTION
@@ -145,7 +145,7 @@ def test_metadata_contract_rejects_development_build_of_stable_candidate() -> No
 def test_metadata_contract_rejects_python_315_upper_bound() -> None:
     message = email.message.Message()
     message["Name"] = "ml4t-live"
-    message["Version"] = "0.1.1"
+    message["Version"] = qualify_artifacts.CANDIDATE_VERSION
     message["Requires-Python"] = ">=3.12,<3.15"
     message["License-Expression"] = "MIT"
 

--- a/tests/unit/test_stable_gate.py
+++ b/tests/unit/test_stable_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import runpy
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -47,6 +48,7 @@ def test_gate_has_explicit_topology_and_rotates_critical_fault_order(tmp_path: P
     stages = qualification_stages(tmp_path, 5)
     names = [stage.name for stage in stages]
     critical = [stage for stage in stages if stage.name.startswith("critical-faults-")]
+    candidate_version = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION", "0.1.1")
 
     assert names[:12] == [
         "ruff-format",
@@ -74,16 +76,16 @@ def test_gate_has_explicit_topology_and_rotates_critical_fault_order(tmp_path: P
     assert len({stage.command[6] for stage in critical}) == 5
     by_name = {stage.name: stage for stage in stages}
     assert by_name["dependency-compatibility"].environment == {
-        "SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.1"
+        "SETUPTOOLS_SCM_PRETEND_VERSION": candidate_version
     }
     assert by_name["artifact-qualification"].environment == {
-        "SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.1"
+        "SETUPTOOLS_SCM_PRETEND_VERSION": candidate_version
     }
     assert by_name["security-qualification"].environment == {
-        "SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.1"
+        "SETUPTOOLS_SCM_PRETEND_VERSION": candidate_version
     }
     assert by_name["build"].environment == {
-        "SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.1",
+        "SETUPTOOLS_SCM_PRETEND_VERSION": candidate_version,
         "SOURCE_DATE_EPOCH": NAMESPACE["source_date_epoch"](),
     }
 


### PR DESCRIPTION
## Outcome

- makes metadata-contract tests use the configured stable candidate version
- verifies stable-gate propagation against the configured version instead of `0.1.1`

## Verification

- both affected modules: 20 passed with the default version
- both affected modules: 20 passed with `SETUPTOOLS_SCM_PRETEND_VERSION=0.1.2`
- deterministic qualification: 1,028 passed, 29 skipped, 85.83% branch coverage
- pre-commit: all checks passed

Closes #82
