### PR TITLE
Bound the post-handshake snapshot in IBBroker.connect()

### DIFF
--- a/src/ml4t/live/brokers/ib.py
+++ b/src/ml4t/live/brokers/ib.py
@@ -45,6 +45,13 @@ from ml4t.live.persistence import redact_sensitive
 
 logger = logging.getLogger(__name__)
 
+# Every await in connect() is bounded, and these name the bounds rather than leaving them
+# as literals at the call sites. The handshake pair keeps the values it has always used;
+# the snapshot bound is new, and is the one whose absence let a connect hang indefinitely.
+IB_CONNECT_HANDSHAKE_TIMEOUT = 15.0  # ib_async's own connectAsync timeout
+IB_CONNECT_TIMEOUT = 20.0  # outer bound, in case connectAsync does not honour its own
+IB_SNAPSHOT_TIMEOUT = 30.0  # positions and open orders, after the handshake succeeds
+
 IB_PENDING_ORDER_STATUSES = frozenset(
     {*IBOrderStatus.ActiveStates, IBOrderStatus.PendingCancel, "PartiallyFilled"}
 )
@@ -181,9 +188,9 @@ class IBBroker:
                     port=self._port,
                     clientId=self._client_id,
                     account=self._account or "",  # Pass account like production
-                    timeout=15,
+                    timeout=IB_CONNECT_HANDSHAKE_TIMEOUT,
                 ),
-                timeout=20,  # Outer timeout wrapper
+                timeout=IB_CONNECT_TIMEOUT,  # Outer timeout wrapper
             )
         except (TimeoutError, ConnectionRefusedError) as e:
             detail = str(redact_sensitive(str(e)))
@@ -216,8 +223,15 @@ class IBBroker:
                     self._market_data_type,
                 )
 
-            await self._sync_positions()
-            await self._sync_orders()
+            # Bounded for the same reason the handshake above is. A Gateway can complete
+            # the handshake and then stop answering requests, and reqPositionsAsync waits
+            # on a reply that never arrives: the caller gets no error, no log line and no
+            # timeout. A notebook run sat 75 minutes here before it was killed, holding the
+            # connection and its scheduling slot the whole time. Failing loudly after
+            # IB_SNAPSHOT_TIMEOUT reuses the handler below, which removes the callbacks,
+            # disconnects and records the snapshot as unavailable.
+            await asyncio.wait_for(self._sync_positions(), timeout=IB_SNAPSHOT_TIMEOUT)
+            await asyncio.wait_for(self._sync_orders(), timeout=IB_SNAPSHOT_TIMEOUT)
         except Exception:
             if callbacks_registered:
                 try:

--- a/tests/unit/test_ib_connect_timeouts.py
+++ b/tests/unit/test_ib_connect_timeouts.py
@@ -1,0 +1,67 @@
+"""Every await in IBBroker.connect() is bounded, including the post-handshake snapshot.
+
+A Gateway can complete the API handshake and then stop answering requests. The handshake
+was already bounded; `_sync_positions()` was not, so `reqPositionsAsync()` waited on a
+reply that never came and `connect()` never returned, logged, or raised. These tests pin
+both halves: the hang now fails, and a healthy connect still succeeds.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ml4t.live.brokers import ib as ib_module
+from ml4t.live.brokers.ib import IBBroker
+
+ACCOUNT = "DU1234567"
+
+
+def _vendor(*, positions_hang: bool) -> MagicMock:
+    """A vendor that completes the handshake, then either answers or never does."""
+    vendor = MagicMock()
+    vendor.connectAsync = AsyncMock(return_value=None)
+    vendor.managedAccounts = MagicMock(return_value=[ACCOUNT])
+    vendor.openTrades = MagicMock(return_value=[])
+    vendor.disconnect = MagicMock()
+    if positions_hang:
+
+        async def never_returns():
+            await asyncio.Event().wait()  # the shape of a request the Gateway never answers
+
+        vendor.reqPositionsAsync = never_returns
+    else:
+        vendor.reqPositionsAsync = AsyncMock(return_value=[])
+    return vendor
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_when_the_position_snapshot_never_answers(monkeypatch):
+    monkeypatch.setattr(ib_module, "IB_SNAPSHOT_TIMEOUT", 0.2)
+    broker = IBBroker(account=ACCOUNT)
+    broker.ib = _vendor(positions_hang=True)
+
+    started = asyncio.get_running_loop().time()
+    with pytest.raises((TimeoutError, RuntimeError)):
+        await asyncio.wait_for(broker.connect(), timeout=5)
+    elapsed = asyncio.get_running_loop().time() - started
+
+    # Without the bound this never returns; the 5s outer wait_for is the test's own
+    # safety net and must not be what ends it.
+    assert elapsed < 3, (
+        f"connect() took {elapsed:.2f}s, so it was not the snapshot bound that ended it"
+    )
+    assert broker.is_connected is False
+    broker.ib.disconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_succeeds_when_the_snapshot_answers():
+    broker = IBBroker(account=ACCOUNT)
+    broker.ib = _vendor(positions_hang=False)
+    broker.ib.isConnected = MagicMock(return_value=True)
+
+    await asyncio.wait_for(broker.connect(), timeout=5)
+
+    assert broker.is_connected is True
+    broker.ib.disconnect.assert_not_called()


### PR DESCRIPTION
`IBBroker.connect()` bounded its handshake and then awaited the position and open-order
snapshot with no timeout at all. A Gateway can complete the API handshake and then stop
answering requests; `reqPositionsAsync()` waits on a reply that never arrives, and the
caller gets no error, no log line and no return.

## How it showed up

Two independent failures on 2026-09-11, against the same Gateway:

- A notebook render sat **75 minutes** inside this call using 7.68 seconds of CPU before it
  was killed, holding its connection and a scheduling slot throughout. Its socket to the
  Gateway was `ESTAB` with bytes queued unread.
- The six-hour paper soak in this repo (run 34594858449) failed after 3h1m56s with
  `paper ib soak failed during controlled_reconnect: RuntimeError`, preceded by
  `API connection failed: TimeoutError()`. Every other qualification stage passed. The
  previous night's run had failed at 3h36m as well, so this is at least the second instance.

A probe on an unused client id reproduced it in 15 seconds: TCP connects, the API handshake
never completes. Established connections kept working, which is why the soak survived three
hours and then died the moment it deliberately reconnected.

## The change

`_sync_positions()` and `_sync_orders()` are wrapped in `asyncio.wait_for`, and the three
timeouts are named instead of appearing as literals at the call site. The handshake pair
keeps the values it has always used (15 and 20); the 30-second snapshot bound is new.

`_sync_orders()` is not actually a network wait today - `openTrades()` reads cached state -
but it is bounded too, so the guarantee belongs to `connect()` rather than to the current
implementation of one method.

A timeout there falls into the handler that already exists, which removes the callbacks,
disconnects, and records the snapshot as unavailable. So a hung Gateway now leaves the
broker in the same state as any other connect failure, rather than half-subscribed.

## Verification

The test fails without the fix and passes with it, which is the only reason to believe it.
With the bound removed and the constants kept, the hang case runs into the test's own
5-second safety net and reports `connect() took 5.01s`; with the bound in place it ends at
the snapshot timeout. A companion test covers a healthy connect, so the pair can fail in
both directions rather than only confirming the unhappy path.

Full unit suite: 1002 passed.

No API surface changes, so this is a patch release and nothing downstream has to move with
it. Readers running chapter 25 against a sick Gateway are the ones who benefit: today they
hang indefinitely with no message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmbqG2FqRWdr6m8UEM7E6g
